### PR TITLE
feat: integrate AlertScanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 Opinionated compatibility mod to integrate diverse circuit network mods better into Pyanodons.
 
+The following mods are made compatible:
+- [Alert Scanner](https://mods.factorio.com/mod/AlertScanner)
+
+If you want to see Pyanodons integration for other mods, feel free to open a discussion thread on the mod portal or a GitHub issue.
+
 ## Legal Notice
 
 Pyanodons Circuit Compatibility is not officially endorsed or recognised by Pyanodons INC.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
 ---------------------------------------------------------------------------------------------------
 Version: 1.0.0
 Date: ????
+  Compatibility:
+    - AlertScanner: [item=alert-scanner] Better subgroup placement if SchallCircuitGroup is installed.
+    - AlertScanner: [item=alert-scanner] Add [item=battery-mk01] to recipe if pyalternativeenergy is installed.

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,0 +1,1 @@
+require("data-updates.AlertScanner")

--- a/data-updates/AlertScanner.lua
+++ b/data-updates/AlertScanner.lua
@@ -1,0 +1,11 @@
+if mods["AlertScanner"] then
+  -- Better subgroup placement
+  if mods["SchallCircuitGroup"] then
+    data.raw.item["alert-scanner"].subgroup = "circuit-input"
+  end
+
+  -- Require battery in recipe as other vanilla circuit network entities do in pyanodons
+  if mods["pyalternativeenergy"] then
+    table.insert(data.raw.recipe["alert-scanner"].ingredients, {type = "item", name = "battery-mk01", amount = 1})
+  end
+end

--- a/info.json
+++ b/info.json
@@ -7,6 +7,10 @@
   "version": "1.0.0",
   "factorio_version": "2.0",
   "dependencies": [
-    "base >= 2.0.0"
+    "base >= 2.0.0",
+    "? AlertScanner >= 0.2.0",
+
+    "(?) pyalternativeenergy >= 3.0.0",
+    "(?) SchallCircuitGroup >= 2.0.0"
   ]
 }


### PR DESCRIPTION
- [item=alert-scanner] Better subgroup placement if SchallCircuitGroup is installed.
- [item=alert-scanner] Add [item=battery-mk01] to recipe if pyalternativeenergy is installed.