### PR TITLE
feat: integrate blueprint_reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Opinionated compatibility mod to integrate diverse circuit network mods better i
 The following mods are made compatible:
 - [Active Rails](https://mods.factorio.com/mod/Active_Rails)
 - [Alert Scanner](https://mods.factorio.com/mod/AlertScanner)
+- [Blueprint reader combinator](https://mods.factorio.com/mod/blueprint_reader)
 
-If you want to see Pyanodons integration for other mods, feel free to open a discussion thread on the mod portal or a GitHub issue.
+If you want to see Pyanodons integration for other circuit network mods, feel free to open a discussion thread on the mod portal or a GitHub issue.
 
 ## Legal Notice
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,3 +7,5 @@ Date: ????
     - Active_Rails: [item=active-rail] Unlock active rail with automated rail transportation technology.
     - AlertScanner: [item=alert-scanner] Better subgroup placement if SchallCircuitGroup is installed.
     - AlertScanner: [item=alert-scanner] Add [item=battery-mk01] to recipe if pyalternativeenergy is installed.
+    - blueprint_reader: [item=blueprint_reader_blueprint-combinator] Better subgroup placement if SchallCircuitGroup is installed.
+    - blueprint_reader: [item=blueprint_reader_blueprint-combinator] Add [item=battery-mk01] to recipe if pyalternativeenergy is installed.

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,2 +1,3 @@
 require("data-updates.Active_Rails")
 require("data-updates.AlertScanner")
+require("data-updates.blueprint_reader")

--- a/data-updates/blueprint_reader.lua
+++ b/data-updates/blueprint_reader.lua
@@ -1,0 +1,11 @@
+if mods["blueprint_reader"] then
+  -- Better subgroup placement
+  if mods["SchallCircuitGroup"] then
+    data.raw.item["blueprint_reader_blueprint-combinator"].subgroup = "circuit-input"
+  end
+
+  -- Require battery in recipe as other vanilla circuit network entities do in pyanodons
+  if mods["pyalternativeenergy"] then
+    table.insert(data.raw.recipe["blueprint_reader_blueprint-combinator"].ingredients, {type = "item", name = "battery-mk01", amount = 1})
+  end
+end

--- a/info.json
+++ b/info.json
@@ -10,6 +10,7 @@
     "base >= 2.0.0",
     "? Active_Rails >= 0.0.2",
     "? AlertScanner >= 0.2.0",
+    "? blueprint_reader >= 2.0.1",
 
     "(?) pyalternativeenergy >= 3.0.0",
     "(?) SchallCircuitGroup >= 2.0.0"


### PR DESCRIPTION
- [item=blueprint_reader_blueprint-combinator] Better subgroup placement if SchallCircuitGroup is installed.
- [item=blueprint_reader_blueprint-combinator] Add [item=battery-mk01] to recipe if pyalternativeenergy is installed.