### PR TITLE
feat: integrate CircuitHUD-V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The following mods are made compatible:
 - [Active Rails](https://mods.factorio.com/mod/Active_Rails)
 - [Alert Scanner](https://mods.factorio.com/mod/AlertScanner)
 - [Blueprint reader combinator](https://mods.factorio.com/mod/blueprint_reader)
+- [Circuit HUD V2](https://mods.factorio.com/mod/CircuitHUD-V2)
 
 If you want to see Pyanodons integration for other circuit network mods, feel free to open a discussion thread on the mod portal or a GitHub issue.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,3 +9,5 @@ Date: ????
     - AlertScanner: [item=alert-scanner] Add [item=battery-mk01] to recipe if pyalternativeenergy is installed.
     - blueprint_reader: [item=blueprint_reader_blueprint-combinator] Better subgroup placement if SchallCircuitGroup is installed.
     - blueprint_reader: [item=blueprint_reader_blueprint-combinator] Add [item=battery-mk01] to recipe if pyalternativeenergy is installed.
+    - CircuitHUD-V2: [item=hud-combinator] Better subgroup placement if SchallCircuitGroup is installed.
+    - CircuitHUD-V2: [item=hud-combinator] Add [item=battery-mk01] to recipe if pyalternativeenergy is installed.

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,3 +1,4 @@
 require("data-updates.Active_Rails")
 require("data-updates.AlertScanner")
 require("data-updates.blueprint_reader")
+require("data-updates.CircuitHUD-V2")

--- a/data-updates/CircuitHUD-V2.lua
+++ b/data-updates/CircuitHUD-V2.lua
@@ -1,0 +1,11 @@
+if mods["CircuitHUD-V2"] then
+  -- Better subgroup placement
+  if mods["SchallCircuitGroup"] then
+    data.raw.item["hud-combinator"].subgroup = "circuit-visual"
+  end
+
+  -- Require battery in recipe as other vanilla circuit network entities do in pyanodons
+  if mods["pyalternativeenergy"] then
+    table.insert(data.raw.recipe["hud-combinator"].ingredients, {type = "item", name = "battery-mk01", amount = 1})
+  end
+end

--- a/info.json
+++ b/info.json
@@ -11,6 +11,7 @@
     "? Active_Rails >= 0.0.2",
     "? AlertScanner >= 0.2.0",
     "? blueprint_reader >= 2.0.1",
+    "? CircuitHUD-V2 >= 2.3.0",
 
     "(?) pyalternativeenergy >= 3.0.0",
     "(?) SchallCircuitGroup >= 2.0.0"


### PR DESCRIPTION
- [item=hud-combinator] Better subgroup placement if SchallCircuitGroup is installed.
- [item=hud-combinator] Add [item=battery-mk01] to recipe if pyalternativeenergy is installed.