### PR TITLE
feat: integrate cybersyn-combinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The following mods are made compatible:
 - [Blueprint reader combinator](https://mods.factorio.com/mod/blueprint_reader)
 - [Circuit HUD V2](https://mods.factorio.com/mod/CircuitHUD-V2)
 - [Compact circuits](https://mods.factorio.com/mod/compaktcircuit)
+- [Cybersyn Combinator](https://mods.factorio.com/mod/cybersyn-combinator)
 
 For the detailed changes, see the changelog.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,3 +15,4 @@ Date: ????
     - compaktcircuit: [item=compaktcircuit-processor][item=compaktcircuit-processor_1x1] Add [item=battery-mk01] to recipe if pyalternativeenergy is installed and compact circuits require power in packed mode.
     - compaktcircuit: [item=compaktcircuit-processor][item=compaktcircuit-processor_1x1] Remove [item=advanced-circuit] from recipe.
     - compaktcircuit: [item=compaktcircuit-processor][item=compaktcircuit-processor_1x1] Unlock after [technology=circuit-network] and use the same science packs.
+    - cybersyn-combinator: [item=cybersyn-constant-combinator] Better subgroup placement if SchallCircuitGroup is installed.

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -1,1 +1,2 @@
 require("data-final-fixes.compaktcircuit")
+require("data-final-fixes.cybersyn-combinator")

--- a/data-final-fixes/cybersyn-combinator.lua
+++ b/data-final-fixes/cybersyn-combinator.lua
@@ -1,0 +1,6 @@
+if mods["cybersyn-combinator"] then
+  -- Better subgroup placement
+  if mods["SchallCircuitGroup"] then
+    data.raw.item["cybersyn-constant-combinator"].subgroup = "circuit-combinator"
+  end
+end

--- a/info.json
+++ b/info.json
@@ -13,6 +13,7 @@
     "? blueprint_reader >= 2.0.1",
     "? CircuitHUD-V2 >= 2.3.0",
     "? compaktcircuit >= 2.0.0",
+    "? cybersyn-combinator >= 2.0.0",
 
     "(?) pyalienlife >= 3.0.0",
     "(?) pyalternativeenergy >= 3.0.0",


### PR DESCRIPTION
- [item=cybersyn-constant-combinator] Better subgroup placement if SchallCircuitGroup is installed.