### PR TITLE
fix(compaktcircuit): use same science packs as advanced-combinators

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,7 +15,7 @@ Date: ????
     - compaktcircuit: [item=compaktcircuit-input][item=compaktcircuit-internal_iopoint][item=compaktcircuit-display] Better subgroup placement with SchallCircuitGroup.
     - compaktcircuit: [item=compaktcircuit-processor][item=compaktcircuit-processor_1x1] Add [item=battery-mk01] to recipe if pyalternativeenergy is installed and compact circuits require power in packed mode.
     - compaktcircuit: [item=compaktcircuit-processor][item=compaktcircuit-processor_1x1] Remove [item=advanced-circuit] from recipe.
-    - compaktcircuit: [item=compaktcircuit-processor][item=compaktcircuit-processor_1x1] Unlock after [technology=circuit-network] and use the same science packs.
+    - compaktcircuit: [technology=compaktcircuit-tech] Unlock after [technology=circuit-network] and use the same science packs as [technology=advanced-combinators].
     - cybersyn-combinator: [item=cybersyn-constant-combinator] Better subgroup placement with SchallCircuitGroup.
     - Cybersyn-Content-Reader: [item=cybersyn-provider-reader][item=cybersyn-requester-reader][item=cybersyn-delivery-reader] Better subgroup placement with SchallCircuitGroup.
     - Cybersyn-Content-Reader: [item=cybersyn-provider-reader][item=cybersyn-requester-reader][item=cybersyn-delivery-reader] Add [item=battery-mk01] to recipe if pyalternativeenergy is installed.

--- a/data-final-fixes/compaktcircuit.lua
+++ b/data-final-fixes/compaktcircuit.lua
@@ -1,5 +1,5 @@
 if mods["compaktcircuit"] then
-  -- Remove advanced circuit and processing unit from recipe, py is hard enough already
+  -- Remove advanced circuit from recipe, py is hard enough already
   for _, recipe in pairs({"compaktcircuit-processor", "compaktcircuit-processor_1x1"}) do
     for _, ingredient_to_remove in pairs({"advanced-circuit"}) do
       local index = nil
@@ -20,7 +20,7 @@ if mods["compaktcircuit"] then
     end
   end
 
-  -- Make tech dependent on circuit network to make it available earlier and use the same science packs
+  -- Make compaktcircuit-tech technology dependent on circuit-network technology to make it available earlier and use the same science packs as advanced-combinators technology
   data.raw.technology["compaktcircuit-tech"].prerequisites = {"circuit-network"}
-  data.raw.technology["compaktcircuit-tech"].unit = data.raw.technology["circuit-network"].unit
+  data.raw.technology["compaktcircuit-tech"].unit = data.raw.technology["advanced-combinators"].unit
 end


### PR DESCRIPTION
- [technology=compaktcircuit-tech] Unlock after [technology=circuit-network] and use the same science packs as [technology=advanced-combinators].