### PR TITLE
chore(deps): restrict maximun version of py mods prior to autotech 2.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,8 @@
 Version: 1.0.0
 Date: ????
   Compatibility:
+    - Restrict maximum py mod versions to versions prior to autotech 2.0 until compatibility with autotech 2.0 is tested and confirmed.
+  Changes:
     - Active_Rails: [item=active-rail] Better subgroup placement with SchallCircuitGroup.
     - Active_Rails: [recipe=active-rail] Add [item=battery-mk01] to recipe if pyalternativeenergy is installed.
     - Active_Rails: [item=active-rail] Unlock with [technology=automated-rail-transportation].

--- a/info.json
+++ b/info.json
@@ -36,11 +36,17 @@
 
     "(?) Automatic_Train_Painter >= 2.0.0",
     "(?) pyalienlife >= 3.0.0",
+    "(?) pyalienlife < 3.0.58",
     "(?) pyalternativeenergy >= 3.0.0",
+    "(?) pyalternativeenergy < 3.1.34",
     "pycoalprocessing >= 3.0.0",
+    "pycoalprocessing < 3.0.43",
     "(?) pyhightech >= 3.0.0",
+    "(?) pyhightech < 3.0.17",
     "(?) pyindustry >= 3.0.0",
+    "(?) pyindustry < 3.0.19",
     "pypostprocessing >= 3.0.22",
+    "pypostprocessing < 3.0.39",
     "SchallCircuitGroup >= 2.0.0"
   ]
 }


### PR DESCRIPTION
Until compatibility with autotech 2.0 is tested and confirmed.