### PR TITLE
feat: integrate aai-signal-transmission

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Opinionated compatibility mod to integrate diverse circuit network mods better i
 
 The following mods are made compatible. For the detailed changes, see the changelog.
 
+- [AAI Signal Transmission](https://mods.factorio.com/mod/aai-signal-transmission)
 - [Active Rails](https://mods.factorio.com/mod/Active_Rails)
 - [Alchemical combinator](https://mods.factorio.com/mod/alchemical-combinator)
 - [Alert Scanner](https://mods.factorio.com/mod/AlertScanner)

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,9 @@
 Version: 1.1.0
 Date: ????
   Changes:
+    - aai-signal-transmission: [item=aai-signal-sender][item=aai-signal-receiver] Better subgroup placement with SchallCircuitGroup.
+    - aai-signal-transmission: [recipe=aai-signal-sender][recipe=aai-signal-receiver] Replace [item=electric-engine-unit] with [item=mechanical-parts-01] and [item=processing-unit] with [item=electronic-circuit] in recipes.
+    - aai-signal-transmission: [technology=aai-signal-transmission] Make dependent on [technology=circuit-network] and [technology=machine-components-mk01] to make it available earlier and use the same science packs as [technology=machine-components-mk01].
     - beltcounter2: [item=belt-arithmetic-combinator] Better subgroup placement with SchallCircuitGroup.
     - beltcounter2: [recipe=belt-arithmetic-combinator] Change recipe to use [item=arithmetic-combinator] instead of [item=power-switch].
 ---------------------------------------------------------------------------------------------------

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,3 +1,4 @@
+require("data-updates.aai-signal-transmission")
 require("data-updates.Active_Rails")
 require("data-updates.alchemical-combinator")
 require("data-updates.AlertScanner")

--- a/data-updates/aai-signal-transmission.lua
+++ b/data-updates/aai-signal-transmission.lua
@@ -1,0 +1,24 @@
+if mods["aai-signal-transmission"] then
+  -- Better subgroup placement with SchallCircuitGroup
+  data.raw.item["aai-signal-sender"].subgroup = "circuit-connection"
+  data.raw.item["aai-signal-receiver"].subgroup = "circuit-connection"
+
+  -- Replace ingredients with more reasonable ones, py is hard enough already
+  for _, recipe in pairs({"aai-signal-sender", "aai-signal-receiver"}) do
+    for replacee, replacement in pairs({["electric-engine-unit"] = "mechanical-parts-01", ["processing-unit"] = "electronic-circuit"}) do
+      local ingredient = nil
+      for i = 1, #data.raw.recipe[recipe].ingredients do
+        ingredient = data.raw.recipe[recipe].ingredients[i]
+
+        if ingredient.name == replacee then
+          data.raw.recipe[recipe].ingredients[i].name = replacement
+          break
+        end
+      end
+    end
+  end
+
+  -- Make aai-signal-transmission technology dependent on circuit-network and machine-components-mk01 technology to make it available earlier and use the same science packs as machine-components-mk01 technology
+  data.raw.technology["aai-signal-transmission"].prerequisites = {"circuit-network", "machine-components-mk01"}
+  data.raw.technology["aai-signal-transmission"].unit = data.raw.technology["machine-components-mk01"].unit
+end

--- a/info.json
+++ b/info.json
@@ -8,6 +8,7 @@
   "factorio_version": "2.0",
   "dependencies": [
     "base >= 2.0.0",
+    "? aai-signal-transmission >= 0.5.0",
     "? Active_Rails >= 0.0.2",
     "? alchemical-combinator >= 1.0.0",
     "? AlertScanner >= 0.2.0",


### PR DESCRIPTION
- [item=aai-signal-sender][item=aai-signal-receiver] Better subgroup placement with SchallCircuitGroup.
- [recipe=aai-signal-sender][recipe=aai-signal-receiver] Replace [item=electric-engine-unit] with [item=mechanical-parts-01] and [item=processing-unit] with [item=electronic-circuit] in recipes.
- [technology=aai-signal-transmission] Make dependent on [technology=circuit-network] and [technology=machine-components-mk01] to make it available earlier and use the same science packs as [technology=machine-components-mk01].